### PR TITLE
LDAP username case-insensivity

### DIFF
--- a/src/core/ldapauthenticator.cpp
+++ b/src/core/ldapauthenticator.cpp
@@ -122,14 +122,18 @@ UserId LdapAuthenticator::validateUser(const QString &username, const QString &p
         return UserId();
     }
 
+    // LDAP is case-insensitive, thus we will lowercase the username, in spite of
+    // a better solution :(
+    const QString lUsername = username.toLower();
+
     // If auth succeeds, but the user has not logged into quassel previously, make
     // a new user for them and return that ID.
     // Users created via LDAP have empty passwords, but authenticator column = LDAP.
     // On the other hand, if auth succeeds and the user already exists, do a final
     // cross-check to confirm we're using the right auth provider.
-    UserId quasselId = Core::validateUser(username, QString());
+    UserId quasselId = Core::validateUser(lUsername, QString());
     if (!quasselId.isValid()) {
-        return Core::addUser(username, QString(), backendId());
+        return Core::addUser(lUsername, QString(), backendId());
     }
     else if (!(Core::checkAuthProvider(quasselId, backendId()))) {
         return 0;


### PR DESCRIPTION
This patches a case sensitivity issue in the core.

LDAP itself is case insensitive, but the LDAP module of the core will keep the case of the usename when creating a local Quassel account. Thus, if you login with the same username but using a different casing, a new internal Quassel account will be creating, resulting in an apparent settings loss (networks, ...).

The patch converts the username to lowercase before handing it to the core.